### PR TITLE
대출 상담 도메인 테이블 정의

### DIFF
--- a/src/main/java/com/example/loan/domain/Counsel.java
+++ b/src/main/java/com/example/loan/domain/Counsel.java
@@ -1,0 +1,51 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Counsel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long counselId;
+
+    @Column(nullable = false, columnDefinition = "datetime COMMENT '신청일자'")
+    private LocalDateTime appliedAt;
+
+    @Column(nullable = false, columnDefinition = "varchar(12) COMMENT '상담 요청자'")
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "varchar(23) COMMENT '전화번호'")
+    private String cellphone;
+
+    @Column(columnDefinition = "varchar(50) DEFAULT NULL COMMENT '상담 요청자 이메일'")
+    private String email;
+
+    @Column(columnDefinition = "text DEFAULT NULL COMMENT '상담메모'")
+    private String memo;
+
+    @Column(columnDefinition = "varchar(50) DEFAULT NULL COMMENT '주소'")
+    private String address;
+
+    @Column(columnDefinition = "varchar(50) DEFAULT NULL COMMENT '상세 주소'")
+    private String addressDetail;
+
+    @Column(columnDefinition = "varchar(5) DEFAULT NULL COMMENT '우편 번호'")
+    private String zipCode;
+
+}


### PR DESCRIPTION
이 PR은 Counsel 엔티티에 대한 필드 추가 및 Soft Delete 기능을 구현한다.

- Counsel 엔티티에 상담 신청일자(appliedAt), 상담 요청자 이름(name), 전화번호(cellphone), 이메일(email), 메모(memo), 주소(address), 상세 주소(addressDetail), 우편 번호(zipCode) 필드를 추가하였으며, 필드별로 SQL 주석을 달아 의미를 명확히 했다.

- 또한, Soft Delete 기능을 구현하여 데이터를 삭제할 때 물리적 삭제 대신 `is_deleted` 플래그를 활용하여 논리적 삭제가 가능하도록 하였다. 이로 인해 삭제된 데이터는 조회에서 제외된다.

