### PR TITLE
대출 상담 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/CounselController.java
+++ b/src/main/java/com/example/loan/controller/CounselController.java
@@ -1,25 +1,27 @@
 package com.example.loan.controller;
 
 
-import com.example.loan.dto.CounselDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.CounselServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import static com.example.loan.dto.CounselDTO.*;
+import static com.example.loan.dto.CounselDTO.Request;
+import static com.example.loan.dto.CounselDTO.Response;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/counsels")
-public class CounselController extends AbstractController{
+public class CounselController extends AbstractController {
     private final CounselServiceImpl counselService;
 
     @PostMapping
-    public ResponseDTO<Response> create (@RequestBody Request request) {
+    public ResponseDTO<Response> create(@RequestBody Request request) {
         return ok(counselService.create(request));
+    }
+
+    @GetMapping("/{counselId}")
+    public ResponseDTO<Response> get(@PathVariable Long counselId) {
+        return ok(counselService.get(counselId));
     }
 }

--- a/src/main/java/com/example/loan/service/CounselService.java
+++ b/src/main/java/com/example/loan/service/CounselService.java
@@ -6,4 +6,5 @@ import com.example.loan.dto.CounselDTO.Response;
 public interface CounselService {
     Response create(CounselDTO.Request request);
 
+    Response get(Long counselId);
 }

--- a/src/main/java/com/example/loan/service/CounselServiceImpl.java
+++ b/src/main/java/com/example/loan/service/CounselServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.loan.service;
 
 import com.example.loan.domain.Counsel;
 import com.example.loan.dto.CounselDTO.Response;
+import com.example.loan.exception.BaseException;
+import com.example.loan.exception.ResultType;
 import com.example.loan.repository.CounselRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -28,5 +30,14 @@ public class CounselServiceImpl implements CounselService {
         Counsel created = counselRepository.save(counsel);
 
         return modelMapper.map(created, Response.class);
+    }
+
+    @Override
+    public Response get(Long counselId) {
+        Counsel counsel = counselRepository.findById(counselId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        return modelMapper.map(counsel, Response.class);
     }
 }

--- a/src/test/java/com/example/loan/service/CounselServiceTest.java
+++ b/src/test/java/com/example/loan/service/CounselServiceTest.java
@@ -3,7 +3,11 @@ package com.example.loan.service;
 import com.example.loan.domain.Counsel;
 import com.example.loan.dto.CounselDTO.Request;
 import com.example.loan.dto.CounselDTO.Response;
+import com.example.loan.exception.BaseException;
+import com.example.loan.exception.ResultType;
 import com.example.loan.repository.CounselRepository;
+import org.assertj.core.api.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -12,6 +16,8 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -54,5 +60,28 @@ class CounselServiceTest {
         Response actual = counselService.create(request);
 
         assertThat(actual.getName()).isSameAs(entity.getName());
+    }
+
+    @Test
+    void Should_ReturnResponseOfExistCounselEntity_When_RequestExistCounsel() {
+        Long findId = 1L;
+
+        Counsel entity = Counsel.builder()
+                .counselId(1L)
+                .build();
+        when(counselRepository.findById(findId)).thenReturn(Optional.ofNullable(entity));
+
+        Response actual = counselService.get(findId);
+
+        assertThat(actual.getCounselId()).isSameAs(findId);
+    }
+
+    @Test
+    void Should_ThrowException_When_RequestNotExistCounselId() {
+        Long findId = 2L;
+
+        when(counselRepository.findById(findId)).thenThrow(new BaseException(ResultType.SYSTEM_ERROR));
+
+        Assertions.assertThrows(BaseException.class, () -> counselService.get(findId));
     }
 }


### PR DESCRIPTION
이 PR은 상담 조회 기능을 추가한다.

1. **CounselController에 상담 조회 API 추가**
   - 클라이언트로부터 상담 ID를 받아 해당 상담 정보를 반환하는 `GET` 메서드 추가.

2. **CounselService 및 CounselServiceImpl에 상담 조회 로직 구현**
   - CounselService 인터페이스에 상담 조회 메서드 정의.
   - CounselServiceImpl에서 상담 ID로 상담 정보를 조회하고, 조회된 데이터를 응답 객체로 변환하는 로직 구현.

3. **CounselServiceTest에 단위 테스트 추가**
   - 존재하는 상담 ID로 조회했을 때 정상적으로 데이터를 반환하는 테스트 추가.
   - 존재하지 않는 상담 ID로 조회 시 예외가 발생하는지 검증하는 테스트 추가.
