### PR TITLE
대출 상담 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/CounselController.java
+++ b/src/main/java/com/example/loan/controller/CounselController.java
@@ -24,4 +24,9 @@ public class CounselController extends AbstractController {
     public ResponseDTO<Response> get(@PathVariable Long counselId) {
         return ok(counselService.get(counselId));
     }
+
+    @PutMapping("/{counselId}")
+    public ResponseDTO<Response> update(@PathVariable Long counselId, @RequestBody Request request) {
+        return ok(counselService.update(counselId, request));
+    }
 }

--- a/src/main/java/com/example/loan/service/CounselService.java
+++ b/src/main/java/com/example/loan/service/CounselService.java
@@ -1,10 +1,12 @@
 package com.example.loan.service;
 
-import com.example.loan.dto.CounselDTO;
-import com.example.loan.dto.CounselDTO.Response;
+import static com.example.loan.dto.CounselDTO.*;
+
 
 public interface CounselService {
-    Response create(CounselDTO.Request request);
+    Response create(Request request);
 
     Response get(Long counselId);
+
+    Response update(Long counselId, Request request);
 }

--- a/src/main/java/com/example/loan/service/CounselServiceImpl.java
+++ b/src/main/java/com/example/loan/service/CounselServiceImpl.java
@@ -40,4 +40,23 @@ public class CounselServiceImpl implements CounselService {
 
         return modelMapper.map(counsel, Response.class);
     }
+
+    @Override
+    public Response update(Long counselId, Request request) {
+        Counsel counsel = counselRepository.findById(counselId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        counsel.setName(request.getName());
+        counsel.setCellPhone(request.getCellPhone());
+        counsel.setEmail(request.getEmail());
+        counsel.setMemo(request.getMemo());
+        counsel.setAddress(request.getAddress());
+        counsel.setAddressDetail(request.getAddressDetail());
+        counsel.setZipCode(request.getZipCode());
+
+        counselRepository.save(counsel);
+
+        return modelMapper.map(counsel, Response.class);
+    }
 }

--- a/src/test/java/com/example/loan/service/CounselServiceTest.java
+++ b/src/test/java/com/example/loan/service/CounselServiceTest.java
@@ -84,4 +84,26 @@ class CounselServiceTest {
 
         Assertions.assertThrows(BaseException.class, () -> counselService.get(findId));
     }
+
+    @Test
+    void Should_ReturnUpdatedResponseOfExistCounselEntity_When_RequestUpdateExistCounselInfo() {
+        Long firstId = 1L;
+
+        Counsel entity = Counsel.builder()
+                .counselId(1L)
+                .name("Member Kim")
+                .build();
+
+        Request request = Request.builder()
+                .name("Member Kang")
+                .build();
+
+        when(counselRepository.save(ArgumentMatchers.any(Counsel.class))).thenReturn(entity);
+        when(counselRepository.findById(firstId)).thenReturn(Optional.ofNullable(entity));
+
+        Response actual = counselService.update(firstId, request);
+
+        assertThat(actual.getCounselId()).isSameAs(firstId);
+        assertThat(actual.getName()).isSameAs(request.getName());
+    }
 }


### PR DESCRIPTION
이 PR은 등록된 상담 정보를 수정할 수 있는 기능을 추가한다.

- **CounselController**
  - 상담 수정 요청을 처리하는 `@PutMapping("/{counselId}")` 메서드를 추가.
  - 특정 상담 ID의 상담 정보를 수정할 수 있는 기능을 구현.

- **CounselService 및 CounselServiceImpl**
  - `CounselService`에 상담 수정 메서드를 정의.
  - `CounselServiceImpl`에서 상담 정보를 조회 후 수정된 내용을 DB에 저장하는 로직을 구현.

- **CounselServiceTest**
  - 상담 정보 수정 기능을 검증하는 테스트 코드 작성.
  - 수정된 상담 정보가 정상적으로 반영되었는지 확인하는 테스트 케이스 추가.