### PR TITLE
대출 상담 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/CounselController.java
+++ b/src/main/java/com/example/loan/controller/CounselController.java
@@ -29,4 +29,10 @@ public class CounselController extends AbstractController {
     public ResponseDTO<Response> update(@PathVariable Long counselId, @RequestBody Request request) {
         return ok(counselService.update(counselId, request));
     }
+
+    @DeleteMapping("/{counselId}")
+    public ResponseDTO<Response> delete(@PathVariable Long counselId) {
+        counselService.delete(counselId);
+        return ok();
+    }
 }

--- a/src/main/java/com/example/loan/service/CounselService.java
+++ b/src/main/java/com/example/loan/service/CounselService.java
@@ -9,4 +9,6 @@ public interface CounselService {
     Response get(Long counselId);
 
     Response update(Long counselId, Request request);
+
+    void delete(Long counselId);
 }

--- a/src/main/java/com/example/loan/service/CounselServiceImpl.java
+++ b/src/main/java/com/example/loan/service/CounselServiceImpl.java
@@ -59,4 +59,14 @@ public class CounselServiceImpl implements CounselService {
 
         return modelMapper.map(counsel, Response.class);
     }
+
+    @Override
+    public void delete(Long counselId) {
+        Counsel counsel = counselRepository.findById(counselId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+        counsel.setIsDeleted(true);
+
+        counselRepository.save(counsel);
+    }
 }

--- a/src/test/java/com/example/loan/service/CounselServiceTest.java
+++ b/src/test/java/com/example/loan/service/CounselServiceTest.java
@@ -19,6 +19,7 @@ import org.modelmapper.ModelMapper;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -105,5 +106,22 @@ class CounselServiceTest {
 
         assertThat(actual.getCounselId()).isSameAs(firstId);
         assertThat(actual.getName()).isSameAs(request.getName());
+    }
+
+    @Test
+    void Should_DeletedCounselEntity_When_RequestDeleteExistCounselInfo() {
+
+        Long targetId = 1L;
+
+        Counsel entity = Counsel.builder()
+                .counselId(1L)
+                .build();
+
+        when(counselRepository.save(ArgumentMatchers.any(Counsel.class))).thenReturn(entity);
+        when(counselRepository.findById(targetId)).thenReturn(Optional.ofNullable(entity));
+
+        counselService.delete(targetId);
+
+        assertThat(entity.getIsDeleted()).isSameAs(true);
     }
 }


### PR DESCRIPTION
이 PR은 상담 삭제 기능을 구현한다.
- **CounselController**
  - 상담 삭제 요청을 처리하는 `@DeleteMapping("/{counselId}")` 메서드 추가.
  - 특정 상담 ID의 상담 정보를 삭제할 수 있는 기능 구현.

- **CounselService 및 CounselServiceImpl**
  - `CounselService`에 상담 삭제 메서드를 정의.
  - `CounselServiceImpl`에서 상담 정보를 논리적으로 삭제하는 로직을 구현 (`isDeleted` 플래그 설정).

- **CounselServiceTest**
  - 상담 삭제 기능을 검증하기 위한 테스트 코드 작성.
  - `isDeleted` 값이 true로 설정되었는지 확인하는 테스트 케이스 추가.