### PR TITLE
대출 신청 도메인 테이블 정의

### DIFF
--- a/src/main/java/com/example/loan/domain/Application.java
+++ b/src/main/java/com/example/loan/domain/Application.java
@@ -1,0 +1,57 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Application extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long applicationId;
+
+    @Column(columnDefinition = "varchar(12) DEFAULT NULL COMMENT '신청자'")
+    private String name;
+
+    @Column(columnDefinition = "varchar(13) DEFAULT NULL COMMENT '전화번호'")
+    private String cellPhone;
+
+    @Column(columnDefinition = "varchar(50) DEFAULT NULL COMMENT '신청자 이메일'")
+    private String email;
+
+    @Column(columnDefinition = "decimal(5,4) DEFAULT NULL COMMENT '금리'")
+    private BigDecimal interestRate;
+
+    @Column(columnDefinition = "decimal(5,4) DEFAULT NULL COMMENT '취급수수료'")
+    private BigDecimal fee;
+
+    @Column(columnDefinition = "datetime DEFAULT NULL COMMENT '만기'")
+    private LocalDateTime maturity;
+
+    @Column(columnDefinition = "decimal(15,2) DEFAULT NULL COMMENT '대출 신청 금액'")
+    private BigDecimal hopeAmount;
+
+    @Column(columnDefinition = "datetime DEFAULT NULL COMMENT '신청일자'")
+    private LocalDateTime appliedAt;
+
+    @Column(columnDefinition = "decimal(15,2) DEFAULT NULL COMMENT '승인 금액'")
+    private BigDecimal approvalAmount;
+
+    @Column(columnDefinition = "datetime DEFAULT NULL COMMENT '약정일자'")
+    private LocalDateTime contractedAt;
+}


### PR DESCRIPTION
이 PR은 대출 신청 도메인 테이블을 정의하고, Soft Delete를 적용한다.

- **Application 엔티티 정의**
  - 대출 신청 정보를 관리하는 테이블로, 신청자 이름, 전화번호, 이메일, 대출 금액, 금리, 수수료 등 다양한 필드를 포함.
  
- **Soft Delete 적용**
  - `is_deleted` 플래그를 사용하여 논리적 삭제를 구현하고, 실제 데이터는 유지하되 삭제된 것처럼 처리.

- **대출 신청 관련 정보 저장**
  - 신청일자, 승인 금액, 약정일자 등 대출 신청 과정에서 발생하는 다양한 정보를 저장하는 필드 추가.
