### PR TITLE
대출 신청 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/ApplicationController.java
+++ b/src/main/java/com/example/loan/controller/ApplicationController.java
@@ -1,15 +1,12 @@
 package com.example.loan.controller;
 
-import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.ApplicationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import static com.example.loan.dto.ApplicationDTO.*;
+import static com.example.loan.dto.ApplicationDTO.Request;
+import static com.example.loan.dto.ApplicationDTO.Response;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,5 +18,10 @@ public class ApplicationController extends AbstractController {
     @PostMapping
     public ResponseDTO<Response> create(@RequestBody Request request) {
         return ok(applicationService.create(request));
+    }
+
+    @GetMapping("/{applicationId}")
+    public ResponseDTO<Response> get(@PathVariable Long applicationId) {
+        return ok(applicationService.get(applicationId));
     }
 }

--- a/src/main/java/com/example/loan/service/ApplicationService.java
+++ b/src/main/java/com/example/loan/service/ApplicationService.java
@@ -6,4 +6,6 @@ import static com.example.loan.dto.ApplicationDTO.Response;
 public interface ApplicationService {
 
     Response create(Request request);
+
+    Response get(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.loan.service;
 
 import com.example.loan.domain.Application;
+import com.example.loan.exception.BaseException;
+import com.example.loan.exception.ResultType;
 import com.example.loan.repository.ApplicationRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -26,5 +28,14 @@ public class ApplicationServiceImpl implements ApplicationService{
         Application applied = applicationRepository.save(application);
 
         return modelMapper.map(applied, Response.class);
+    }
+
+    @Override
+    public Response get(Long applicationId) {
+        Application application = applicationRepository.findById(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        return modelMapper.map(application, Response.class);
     }
 }

--- a/src/test/java/com/example/loan/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/loan/service/ApplicationServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 import static com.example.loan.dto.ApplicationDTO.Request;
 import static com.example.loan.dto.ApplicationDTO.Response;
@@ -52,6 +53,20 @@ class ApplicationServiceTest {
 
         assertThat(actual.getHopeAmount()).isSameAs(entity.getHopeAmount());
         assertThat(actual.getName()).isSameAs(entity.getName());
+    }
+
+    @Test
+    void Should_ReturnResponseOfExistingApplicationEntity_when_RequestExistApplicationId() {
+        Long findId = 1L;
+
+        Application entity = Application.builder()
+                .applicationId(1L)
+                .build();
+        when(applicationRepository.findById(findId)).thenReturn(Optional.ofNullable(entity));
+
+        Response actual = applicationService.get(findId);
+
+        assertThat(actual.getApplicationId()).isSameAs(findId);
     }
 
 }


### PR DESCRIPTION
이 PR은 대출 신청 조회 기능을 구현한다.
- **ApplicationController에 조회 기능 추가**
  - 대출 신청 정보를 GET 메서드로 조회할 수 있는 API 구현.
  - `applicationId`를 통해 특정 대출 신청 정보를 조회 후 응답으로 반환.

- **ApplicationService 및 ApplicationServiceImpl 구현**
  - 대출 신청 조회 기능을 위한 `get` 메서드를 추가하여, 데이터를 조회하고 DTO로 변환하는 로직 구현.
  - `ApplicationRepository`를 사용해 해당 신청 정보를 데이터베이스에서 조회.

- **ApplicationServiceTest 작성**
  - 대출 신청 조회 기능이 정상적으로 동작하는지 확인하기 위한 단위 테스트 작성.
  - 특정 ID를 조회했을 때 데이터가 정확하게 반환되는지 검증.