### PR TITLE
대출 신청 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/ApplicationController.java
+++ b/src/main/java/com/example/loan/controller/ApplicationController.java
@@ -24,4 +24,9 @@ public class ApplicationController extends AbstractController {
     public ResponseDTO<Response> get(@PathVariable Long applicationId) {
         return ok(applicationService.get(applicationId));
     }
+
+    @PutMapping("/{applicationId}")
+    public ResponseDTO<Response> update(@PathVariable Long applicationId, @RequestBody Request request) {
+        return ok(applicationService.update(applicationId, request));
+    }
 }

--- a/src/main/java/com/example/loan/service/ApplicationService.java
+++ b/src/main/java/com/example/loan/service/ApplicationService.java
@@ -8,4 +8,6 @@ public interface ApplicationService {
     Response create(Request request);
 
     Response get(Long applicationId);
+
+    Response update(Long applicationId, Request request);
 }

--- a/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
@@ -38,4 +38,20 @@ public class ApplicationServiceImpl implements ApplicationService{
 
         return modelMapper.map(application, Response.class);
     }
+
+    @Override
+    public Response update(Long applicationId, Request request) {
+        Application application = applicationRepository.findById(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        application.setName(request.getName());
+        application.setCellPhone(request.getCellPhone());
+        application.setEmail(request.getEmail());
+        application.setHopeAmount(request.getHopeAmount());
+
+        applicationRepository.save(application);
+
+        return modelMapper.map(application, Response.class);
+    }
 }

--- a/src/test/java/com/example/loan/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/loan/service/ApplicationServiceTest.java
@@ -69,4 +69,26 @@ class ApplicationServiceTest {
         assertThat(actual.getApplicationId()).isSameAs(findId);
     }
 
+    @Test
+    void Should_ReturnUpdatedResponseOfExistApplicationEntity_when_RequestUpdateApplicationInfo() {
+        Long findId = 1L;
+
+        Application entity = Application.builder()
+                .applicationId(1L)
+                .hopeAmount(BigDecimal.valueOf(50000000))
+                .build();
+
+        Request request = Request.builder()
+                .hopeAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        when(applicationRepository.save(ArgumentMatchers.any(Application.class))).thenReturn(entity);
+        when(applicationRepository.findById(findId)).thenReturn(Optional.ofNullable(entity));
+
+        Response actual = applicationService.update(findId, request);
+
+        assertThat(actual.getApplicationId()).isSameAs(findId);
+        assertThat(actual.getHopeAmount()).isSameAs(request.getHopeAmount());
+    }
+
 }


### PR DESCRIPTION
이 PR은 대출 신청 수정 기능을 구현한다.

- **ApplicationController에 수정 기능 추가**
  - 대출 신청 정보를 수정하는 PUT API를 구현.
  - `applicationId`와 요청된 수정 데이터를 받아 정보를 갱신.

- **ApplicationService 및 ApplicationServiceImpl 구현**
  - 기존 대출 신청 정보를 수정하는 비즈니스 로직 추가.
  - 데이터베이스에 저장된 정보를 수정 후 응답으로 반환.

- **ApplicationServiceTest 작성**
  - 수정 기능이 정상적으로 동작하는지 검증하는 단위 테스트 작성.
  - 요청된 수정 사항이 올바르게 반영되고 응답되는지 확인.