### PR TITLE
대출 신청 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/ApplicationController.java
+++ b/src/main/java/com/example/loan/controller/ApplicationController.java
@@ -29,4 +29,11 @@ public class ApplicationController extends AbstractController {
     public ResponseDTO<Response> update(@PathVariable Long applicationId, @RequestBody Request request) {
         return ok(applicationService.update(applicationId, request));
     }
+
+    @DeleteMapping("/{applicationId}")
+    public ResponseDTO<Void> delete(@PathVariable Long applicationId) {
+        applicationService.delete(applicationId);
+
+        return ok();
+    }
 }

--- a/src/main/java/com/example/loan/service/ApplicationService.java
+++ b/src/main/java/com/example/loan/service/ApplicationService.java
@@ -10,4 +10,6 @@ public interface ApplicationService {
     Response get(Long applicationId);
 
     Response update(Long applicationId, Request request);
+
+    void delete(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
@@ -54,4 +54,15 @@ public class ApplicationServiceImpl implements ApplicationService{
 
         return modelMapper.map(application, Response.class);
     }
+
+    @Override
+    public void delete(Long applicationId) {
+        Application application = applicationRepository.findById(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        application.setIsDeleted(true);
+
+        applicationRepository.save(application);
+    }
 }

--- a/src/test/java/com/example/loan/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/loan/service/ApplicationServiceTest.java
@@ -91,4 +91,19 @@ class ApplicationServiceTest {
         assertThat(actual.getHopeAmount()).isSameAs(request.getHopeAmount());
     }
 
+    @Test
+    void Should_DeletedApplicationEntity_When_RequestDeleteExistApplicationInfo() {
+        Long targetId = 1L;
+
+        Application entity = Application.builder()
+                .applicationId(1L)
+                .build();
+
+        when(applicationRepository.save(ArgumentMatchers.any(Application.class))).thenReturn(entity);
+        when(applicationRepository.findById(targetId)).thenReturn(Optional.ofNullable(entity));
+
+        applicationService.delete(targetId);
+
+        assertThat(entity.getIsDeleted()).isSameAs(true);
+    }
 }


### PR DESCRIPTION
이 PR은 대출 신청 삭제 기능을 구현한다.

- **ApplicationController에 삭제 기능 추가**
  - 대출 신청 정보를 삭제하는 DELETE API를 구현.
  - `applicationId`를 통해 특정 대출 신청 정보를 논리적으로 삭제 후 성공 응답 반환.

- **ApplicationService 및 ApplicationServiceImpl 구현**
  - 대출 신청 삭제 기능을 추가하여, 삭제 요청 시 `isDeleted` 플래그를 true로 설정하여 논리적 삭제를 처리.
  - 데이터베이스에서 실제로 삭제하지 않고 논리적으로 삭제하는 로직 구현.

- **ApplicationServiceTest 작성**
  - 삭제 기능이 정상적으로 동작하는지 검증하기 위한 단위 테스트 작성.
  - `isDeleted` 필드가 true로 설정되는지 확인.