### PR TITLE
약관 등록 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,6 +287,7 @@ gradle-app.setting
 # Gradle specific files
 .gradle/
 **/build/
+gradle.xml
 
 # IntelliJ IDEA specific
 .idea/

--- a/src/main/java/com/example/loan/controller/TermsController.java
+++ b/src/main/java/com/example/loan/controller/TermsController.java
@@ -1,0 +1,25 @@
+package com.example.loan.controller;
+
+import com.example.loan.dto.ResponseDTO;
+import com.example.loan.dto.TermsDTO;
+import com.example.loan.service.TermsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.loan.dto.TermsDTO.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/terms")
+public class TermsController extends AbstractController{
+
+    private final TermsService termsService;
+
+    @PostMapping
+    public ResponseDTO<Response> create(@RequestBody Request request) {
+        return ok(termsService.create(request));
+    }
+}

--- a/src/main/java/com/example/loan/domain/Terms.java
+++ b/src/main/java/com/example/loan/domain/Terms.java
@@ -1,0 +1,31 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Terms extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long termsId;
+
+    @Column(columnDefinition = "varchar(255) NOT NULL COMMENT '약관'")
+    private String name;
+
+    @Column(columnDefinition = "varchar(255) NOT NULL COMMENT '약관상세 URL'")
+    private String termsDetailUrl;
+}

--- a/src/main/java/com/example/loan/dto/CounselDTO.java
+++ b/src/main/java/com/example/loan/dto/CounselDTO.java
@@ -12,8 +12,6 @@ public class CounselDTO {
     @Getter
     public static class Request {
 
-        private Long counselId;
-
         private String name;
 
         private String cellPhone;
@@ -27,12 +25,6 @@ public class CounselDTO {
         private String addressDetail;
 
         private String zipCode;
-
-        private LocalDateTime appliedAt;
-
-        private LocalDateTime createAt;
-
-        private LocalDateTime updateAt;
     }
 
     @NoArgsConstructor

--- a/src/main/java/com/example/loan/dto/TermsDTO.java
+++ b/src/main/java/com/example/loan/dto/TermsDTO.java
@@ -1,0 +1,37 @@
+package com.example.loan.dto;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public class TermsDTO implements Serializable {
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class Request {
+
+        private String name;
+
+        private String termsDetailUrl;
+
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Response{
+        private Long termsId;
+
+        private String name;
+
+        private String termsDetailUrl;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/com/example/loan/repository/TermsRepository.java
+++ b/src/main/java/com/example/loan/repository/TermsRepository.java
@@ -1,0 +1,9 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+}

--- a/src/main/java/com/example/loan/service/TermsService.java
+++ b/src/main/java/com/example/loan/service/TermsService.java
@@ -1,0 +1,8 @@
+package com.example.loan.service;
+
+import static com.example.loan.dto.TermsDTO.*;
+
+public interface TermsService {
+
+    Response create(Request request);
+}

--- a/src/main/java/com/example/loan/service/TermsServiceImpl.java
+++ b/src/main/java/com/example/loan/service/TermsServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.loan.service;
+
+import com.example.loan.domain.Terms;
+import com.example.loan.dto.TermsDTO;
+import com.example.loan.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import static com.example.loan.dto.TermsDTO.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TermsServiceImpl implements TermsService{
+
+    private final TermsRepository termsRepository;
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Response create(Request request) {
+
+        Terms terms = modelMapper.map(request, Terms.class);
+        Terms created = termsRepository.save(terms);
+
+        return modelMapper.map(created, Response.class);
+    }
+}

--- a/src/test/java/com/example/loan/service/TermsServiceImplTest.java
+++ b/src/test/java/com/example/loan/service/TermsServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.example.loan.service;
+
+import com.example.loan.domain.Terms;
+import com.example.loan.dto.TermsDTO;
+import com.example.loan.repository.TermsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Repository;
+
+import static com.example.loan.dto.TermsDTO.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TermsServiceImplTest {
+
+    @InjectMocks
+    TermsServiceImpl termsService;
+
+    @Mock
+    private TermsRepository termsRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    @Test
+    void Should_ReturnResponseOfNewTermsEntity_When_RequestTerms() {
+        Terms entity = Terms.builder()
+                .name("대출 이용 약관")
+                .termsDetailUrl("https://abc-storage.acc/asdfasdf")
+                .build();
+
+        Request request = Request.builder()
+                .name("대출 이용 약관")
+                .termsDetailUrl("https://abc-storage.acc/asdfasdf")
+                .build();
+
+        when(termsRepository.save(ArgumentMatchers.any(Terms.class))).thenReturn(entity);
+
+        Response actual = termsService.create(request);
+
+        assertThat(actual.getName()).isSameAs(entity.getName());
+        assertThat(actual.getTermsDetailUrl()).isSameAs(entity.getTermsDetailUrl());
+
+
+    }
+}


### PR DESCRIPTION
이 PR은 약관 등록 기능을 구현한다.

- **TermsController에 약관 등록 기능 추가**
  - 약관 정보를 등록하는 POST API 구현.
  - 관리자가 약관 이름과 상세 URL을 입력하여 약관을 등록할 수 있도록 처리.

- **TermsService 및 TermsServiceImpl 구현**
  - 약관 등록 로직을 처리하는 `create` 메서드를 구현.
  - `ModelMapper`를 사용해 DTO를 엔티티로 변환한 후, 약관 정보를 데이터베이스에 저장.

- **TermsRepository 추가**
  - 약관 정보를 관리하고 데이터베이스와 상호작용하는 JPA 기반의 `TermsRepository` 추가.

- **TermsServiceTest 작성**
  - 약관 등록 기능의 단위 테스트를 통해 기능 검증.
  - 약관이 정상적으로 등록되고 응답으로 반환되는지 확인.