### PR TITLE
약관 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/TermsController.java
+++ b/src/main/java/com/example/loan/controller/TermsController.java
@@ -4,10 +4,9 @@ import com.example.loan.dto.ResponseDTO;
 import com.example.loan.dto.TermsDTO;
 import com.example.loan.service.TermsService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.example.loan.dto.TermsDTO.*;
 
@@ -21,5 +20,10 @@ public class TermsController extends AbstractController{
     @PostMapping
     public ResponseDTO<Response> create(@RequestBody Request request) {
         return ok(termsService.create(request));
+    }
+
+    @GetMapping
+    public ResponseDTO<List<Response>> getAll() {
+        return ok(termsService.getAll());
     }
 }

--- a/src/main/java/com/example/loan/service/TermsService.java
+++ b/src/main/java/com/example/loan/service/TermsService.java
@@ -1,8 +1,12 @@
 package com.example.loan.service;
 
+import java.util.List;
+
 import static com.example.loan.dto.TermsDTO.*;
 
 public interface TermsService {
 
     Response create(Request request);
+
+    List<Response> getAll();
 }

--- a/src/main/java/com/example/loan/service/TermsServiceImpl.java
+++ b/src/main/java/com/example/loan/service/TermsServiceImpl.java
@@ -8,6 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.example.loan.dto.TermsDTO.*;
 
 @Service
@@ -26,5 +29,12 @@ public class TermsServiceImpl implements TermsService{
         Terms created = termsRepository.save(terms);
 
         return modelMapper.map(created, Response.class);
+    }
+
+    @Override
+    public List<Response> getAll() {
+        List<Terms> termsList = termsRepository.findAll();
+
+        return termsList.stream().map(t -> modelMapper.map(t, Response.class)).collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/example/loan/service/TermsServiceImplTest.java
+++ b/src/test/java/com/example/loan/service/TermsServiceImplTest.java
@@ -10,6 +10,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static com.example.loan.dto.TermsDTO.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
@@ -46,7 +50,26 @@ class TermsServiceImplTest {
 
         assertThat(actual.getName()).isSameAs(entity.getName());
         assertThat(actual.getTermsDetailUrl()).isSameAs(entity.getTermsDetailUrl());
-
-
     }
+
+    @Test
+    void Should_ReturnAllResponseOfExistTermsEntities_When_RequestTermsList() {
+        Terms entityA = Terms.builder()
+                .name("대출 이용약관 1")
+                .termsDetailUrl("https://abc-storage.acc/asdfasdf")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .name("대출 이용약관 2")
+                .termsDetailUrl("https://zxc-storage.zcc/zxcvxcv")
+                .build();
+        List<Terms> list = new ArrayList<>(Arrays.asList(entityA, entityB));
+
+        when(termsRepository.findAll()).thenReturn(list);
+
+        List<Response> actual = termsService.getAll();
+
+        assertThat(actual.size()).isSameAs(list.size());
+    }
+
 }


### PR DESCRIPTION
이 PR은 약관 전체 조회 기능을 구현한다.

- **TermsController에 조회 기능 추가**
  - 모든 약관 정보를 리스트 형태로 반환하는 GET API 구현.
  - 약관이 하나 이상일 경우 리스트로 반환하고, 약관이 없을 때는 빈 리스트 반환.

- **TermsService 및 TermsServiceImpl 구현**
  - `getAll()` 메서드를 통해 모든 약관 정보를 조회하는 기능 구현.
  - `termsRepository.findAll()`을 호출하여 모든 약관 엔티티를 조회하고 DTO로 변환.

- **TermsServiceTest 작성**
  - 약관 조회 기능에 대한 단위 테스트 작성.
  - 여러 개의 약관이 등록되어 있을 때, 리스트로 반환되는지 확인.
  - `termsRepository.findAll()`이 정상적으로 호출되고 결과를 반환하는지 검증.