### PR TITLE
대출 신청 이용 약관 등록 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/ApplicationController.java
+++ b/src/main/java/com/example/loan/controller/ApplicationController.java
@@ -1,10 +1,12 @@
 package com.example.loan.controller;
 
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.ApplicationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static com.example.loan.dto.ApplicationDTO.*;
 import static com.example.loan.dto.ApplicationDTO.Request;
 import static com.example.loan.dto.ApplicationDTO.Response;
 
@@ -35,5 +37,10 @@ public class ApplicationController extends AbstractController {
         applicationService.delete(applicationId);
 
         return ok();
+    }
+
+    @PostMapping("/{applicationId}/terms")
+    public ResponseDTO<Boolean> acceptTerms(@PathVariable Long applicationId, @RequestBody AcceptTerms request){
+        return ok(applicationService.acceptTerms(applicationId, request));
     }
 }

--- a/src/main/java/com/example/loan/domain/AcceptTerms.java
+++ b/src/main/java/com/example/loan/domain/AcceptTerms.java
@@ -1,0 +1,32 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class AcceptTerms extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    @EqualsAndHashCode.Include
+    private Long acceptTermsId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '약관 ID'")
+    private Long termsId;
+}

--- a/src/main/java/com/example/loan/dto/ApplicationDTO.java
+++ b/src/main/java/com/example/loan/dto/ApplicationDTO.java
@@ -3,6 +3,8 @@ package com.example.loan.dto;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,5 +53,13 @@ public class ApplicationDTO implements Serializable {
         private LocalDateTime createdAt;
 
         private LocalDateTime updatedAt;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class AcceptTerms {
+        List<Long> acceptTermsIds;
     }
 }

--- a/src/main/java/com/example/loan/repository/AcceptTermsRepository.java
+++ b/src/main/java/com/example/loan/repository/AcceptTermsRepository.java
@@ -1,0 +1,10 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.AcceptTerms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AcceptTermsRepository extends JpaRepository<AcceptTerms, Long> {
+
+}

--- a/src/main/java/com/example/loan/service/ApplicationService.java
+++ b/src/main/java/com/example/loan/service/ApplicationService.java
@@ -1,7 +1,8 @@
 package com.example.loan.service;
 
-import static com.example.loan.dto.ApplicationDTO.Request;
-import static com.example.loan.dto.ApplicationDTO.Response;
+import com.example.loan.dto.ApplicationDTO.AcceptTerms;
+import com.example.loan.dto.ApplicationDTO.Request;
+import com.example.loan.dto.ApplicationDTO.Response;
 
 public interface ApplicationService {
 
@@ -12,4 +13,6 @@ public interface ApplicationService {
     Response update(Long applicationId, Request request);
 
     void delete(Long applicationId);
+
+    Boolean acceptTerms(Long applicationId, AcceptTerms request);
 }

--- a/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
+++ b/src/main/java/com/example/loan/service/ApplicationServiceImpl.java
@@ -1,23 +1,37 @@
 package com.example.loan.service;
 
+import com.example.loan.domain.AcceptTerms;
 import com.example.loan.domain.Application;
+import com.example.loan.domain.Terms;
+import com.example.loan.dto.ApplicationDTO;
+import com.example.loan.dto.ApplicationDTO.Request;
+import com.example.loan.dto.ApplicationDTO.Response;
 import com.example.loan.exception.BaseException;
 import com.example.loan.exception.ResultType;
+import com.example.loan.repository.AcceptTermsRepository;
 import com.example.loan.repository.ApplicationRepository;
+import com.example.loan.repository.TermsRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-
-import static com.example.loan.dto.ApplicationDTO.Request;
-import static com.example.loan.dto.ApplicationDTO.Response;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ApplicationServiceImpl implements ApplicationService{
 
     private final ApplicationRepository applicationRepository;
+
+    private final TermsRepository termsRepository;
+
+    private final AcceptTermsRepository acceptTermsRepository;
+
     private final ModelMapper modelMapper;
 
     @Override
@@ -64,5 +78,39 @@ public class ApplicationServiceImpl implements ApplicationService{
         application.setIsDeleted(true);
 
         applicationRepository.save(application);
+    }
+
+    @Override
+    public Boolean acceptTerms(Long applicationId, ApplicationDTO.AcceptTerms request) {
+        applicationRepository.findById(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        List<Terms> termsList = termsRepository.findAll(Sort.by(Direction.ASC, "termsId"));
+        if (termsList.isEmpty()) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        List<Long> acceptTermsIds = request.getAcceptTermsIds();
+        if (termsList.size() != acceptTermsIds.size()) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        List<Long> termsIds = termsList.stream().map(Terms::getTermsId).collect(Collectors.toList());
+        Collections.sort(acceptTermsIds);
+
+        if (!termsIds.containsAll(acceptTermsIds)) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        for (Long termsId : acceptTermsIds) {
+            AcceptTerms accepted = AcceptTerms.builder()
+                    .termsId(termsId)
+                    .applicationId(applicationId)
+                    .build();
+            acceptTermsRepository.save(accepted);
+        }
+
+        return true;
     }
 }

--- a/src/test/java/com/example/loan/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/loan/service/ApplicationServiceTest.java
@@ -1,7 +1,14 @@
 package com.example.loan.service;
 
+import com.example.loan.domain.AcceptTerms;
 import com.example.loan.domain.Application;
+import com.example.loan.domain.Terms;
+import com.example.loan.dto.ApplicationDTO;
+import com.example.loan.exception.BaseException;
+import com.example.loan.repository.AcceptTermsRepository;
 import com.example.loan.repository.ApplicationRepository;
+import com.example.loan.repository.TermsRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -10,13 +17,17 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static com.example.loan.dto.ApplicationDTO.Request;
 import static com.example.loan.dto.ApplicationDTO.Response;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +38,12 @@ class ApplicationServiceTest {
 
     @Mock
     private ApplicationRepository applicationRepository;
+
+    @Mock
+    private TermsRepository termsRepository;
+
+    @Mock
+    private AcceptTermsRepository acceptTermsRepository;
 
     @Spy
     private ModelMapper modelMapper;
@@ -105,5 +122,98 @@ class ApplicationServiceTest {
         applicationService.delete(targetId);
 
         assertThat(entity.getIsDeleted()).isSameAs(true);
+    }
+
+
+    @Test
+    void Should_AddAcceptTerms_When_RequestAcceptTermsOfApplication() {
+        Terms entityA = Terms.builder()
+                .termsId(1L)
+                .name("대출 이용 약관 1")
+                .termsDetailUrl("https://abc-storage.acc/dslfjdlsfjlsdddads")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .termsId(2L)
+                .name("대출 이용 약관 2")
+                .termsDetailUrl("https://abc-storage.acc/dslfjdlsfjlsdweqwq")
+                .build();
+
+        List<Long> acceptTerms = Arrays.asList(1L, 2L);
+
+        ApplicationDTO.AcceptTerms request = ApplicationDTO.AcceptTerms.builder()
+                .acceptTermsIds(acceptTerms)
+                .build();
+
+        Long findId = 1L;
+
+        when(applicationRepository.findById(findId)).thenReturn(
+                Optional.ofNullable(Application.builder().build()));
+        when(termsRepository.findAll(Sort.by(Sort.Direction.ASC, "termsId"))).thenReturn(Arrays.asList(entityA, entityB));
+        when(acceptTermsRepository.save(ArgumentMatchers.any(AcceptTerms.class))).thenReturn(AcceptTerms.builder().build());
+
+
+        Boolean actual = applicationService.acceptTerms(findId, request);
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void Should_ThrowException_When_RequestNotAllAcceptTermsOfApplication() {
+        Terms entityA = Terms.builder()
+                .termsId(1L)
+                .name("대출 이용 약관 1")
+                .termsDetailUrl("https://abc-storage.acc/dslfjdlsfjlsdddads")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .termsId(2L)
+                .name("대출 이용 약관 2")
+                .termsDetailUrl("https://abc-storage.acc/dslfjdlsfjlsdweqwq")
+                .build();
+
+        List<Long> acceptTerms = Arrays.asList(1L);
+
+        ApplicationDTO.AcceptTerms request = ApplicationDTO.AcceptTerms.builder()
+                .acceptTermsIds(acceptTerms)
+                .build();
+
+        Long findId = 1L;
+
+        when(applicationRepository.findById(findId)).thenReturn(
+                Optional.ofNullable(Application.builder().build()));
+        when(termsRepository.findAll(Sort.by(Sort.Direction.ASC, "termsId"))).thenReturn(Arrays.asList(entityA, entityB));
+
+        assertThrows(BaseException.class, () -> applicationService.acceptTerms(findId, request));
+
+    }
+
+    @Test
+    void Should_ThrowException_When_RequestNotExistAcceptTermsOfApplication() {
+        Terms entityA = Terms.builder()
+                .termsId(1L)
+                .name("대출 이용 약관 1")
+                .termsDetailUrl("https://abc-storage.acc/dslfjdlsfjlsdddads")
+                .build();
+
+        Terms entityB = Terms.builder()
+                .termsId(2L)
+                .name("대출 이용 약관 2")
+                .termsDetailUrl("https://abc-storage.acc/dslfjdlsfjlsdweqwq")
+                .build();
+
+        List<Long> acceptTerms = Arrays.asList(1L, 3L);
+
+        ApplicationDTO.AcceptTerms request = ApplicationDTO.AcceptTerms.builder()
+                .acceptTermsIds(acceptTerms)
+                .build();
+
+        Long findId = 1L;
+
+        when(applicationRepository.findById(findId)).thenReturn(
+                Optional.ofNullable(Application.builder().build()));
+        when(termsRepository.findAll(Sort.by(Sort.Direction.ASC, "termsId"))).thenReturn(Arrays.asList(entityA, entityB));
+
+        assertThrows(BaseException.class, () -> applicationService.acceptTerms(findId, request));
+
     }
 }


### PR DESCRIPTION
이 PR은 대출 신청 시 신청자가 등록된 약관에 동의하고 그 정보를 저장하는 기능을 구현한다.

**AcceptTerms 엔티티 추가**
- 신청자가 동의한 약관의 ID와 신청 ID를 저장하는 `AcceptTerms` 엔티티를 추가하여 동의한 약관을 기록한다.

**ApplicationController에 약관 동의 API 추가**
- 신청자가 선택한 약관 ID 목록을 통해 약관 동의를 처리하는 `acceptTerms` 메서드를 추가한다.

**ApplicationDTO 수정**
- 약관 동의 데이터를 처리할 수 있도록 `AcceptTerms` 클래스를 추가하여 데이터를 전달받고 처리할 수 있도록 수정한다.

**AcceptTermsRepository 추가**
- 약관 동의 정보를 저장하고 관리할 수 있는 `AcceptTermsRepository`를 추가한다.

**ApplicationService 및 ApplicationServiceImpl에 약관 동의 로직 구현**
- 신청자가 선택한 약관이 올바르게 등록된 약관인지 검증하고, 동의 정보를 데이터베이스에 저장하는 로직을 추가한다.

**테스트 케이스 추가**
- 정상적인 약관 동의 처리 및 예외 상황에 대한 테스트 케이스를 추가한다.
