### PR TITLE
대출 신청 서류 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/ApplicationController.java
+++ b/src/main/java/com/example/loan/controller/ApplicationController.java
@@ -80,4 +80,10 @@ public class ApplicationController extends AbstractController {
         }).collect(Collectors.toList());
         return ok(fileInfos);
     }
+
+    @DeleteMapping("/files")
+    public ResponseDTO<Void> deleteAll() {
+        fileStorageService.deleteAll();
+        return ok();
+    }
 }

--- a/src/main/java/com/example/loan/service/FileStorageService.java
+++ b/src/main/java/com/example/loan/service/FileStorageService.java
@@ -14,4 +14,6 @@ public interface FileStorageService {
 
     Stream<Path> loadAll();
 
+    void deleteAll();
+
 }

--- a/src/main/java/com/example/loan/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/example/loan/service/FileStorageServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
+import org.springframework.util.FileSystemUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -58,5 +59,10 @@ public class FileStorageServiceImpl implements FileStorageService {
         } catch (Exception e) {
             throw new BaseException(ResultType.SYSTEM_ERROR);
         }
+    }
+
+    @Override
+    public void deleteAll() {
+        FileSystemUtils.deleteRecursively(Paths.get(uploadPath).toFile());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,6 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
-      location: /Users/eunchan/Desktop
+      location: /Users/eunchan/Desktop/loan
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
이 PR은 파일 삭제 기능을 구현하고, 테스트를 위한 경로 설정을 포함한다.

- ApplicationController에 파일 삭제 API 추가
- FileStorageService에 파일 삭제 메서드 추가
- FileStorageServiceImpl에서 모든 파일과 폴더를 삭제하는 기능 구현
- 테스트를 위해 application.yml 파일 경로를 /Users/eunchan/Desktop/loan으로 수정
- 파일 삭제 테스트 완료, 테스트 시 별도의 폴더를 사용하여 안전하게 테스트 진행





