### PR TITLE
대출 심사 도메인 테이블 정의

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-fastcampus-loan

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'fastcampus-loan'
+rootProject.name = 'loan'

--- a/src/main/java/com/example/loan/domain/Judgment.java
+++ b/src/main/java/com/example/loan/domain/Judgment.java
@@ -1,0 +1,34 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Judgment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long judgmentId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "varchar(12) NOT NULL COMMENT '심사자'")
+    private String name;
+
+    @Column(columnDefinition = "decimal(15,2) NOT NULL COMMENT '승인 금액'")
+    private BigDecimal approvalAmount;
+}


### PR DESCRIPTION
이 PR은 대출 심사 도메인을 정의하고, 승인 금액과 심사자 정보를 저장하는 기능을 추가한다. 


