### PR TITLE
대출 심사 등록 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -1,0 +1,25 @@
+package com.example.loan.controller;
+
+import com.example.loan.dto.ResponseDTO;
+import com.example.loan.service.JudgmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.loan.dto.JudgmentDTO.Request;
+import static com.example.loan.dto.JudgmentDTO.Response;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/judgments")
+public class JudgmentController extends AbstractController {
+
+    private final JudgmentService judgmentService;
+
+    @PostMapping
+    public ResponseDTO<Response> create(@RequestBody Request request) {
+        return ok(judgmentService.create(request));
+    }
+}

--- a/src/main/java/com/example/loan/dto/JudgmentDTO.java
+++ b/src/main/java/com/example/loan/dto/JudgmentDTO.java
@@ -1,0 +1,43 @@
+package com.example.loan.dto;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class JudgmentDTO implements Serializable {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Request{
+        private Long applicationId;
+
+        private String name;
+
+        private BigDecimal approvalAmount;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Response{
+
+        private Long judgmentId;
+
+        private Long applicationId;
+
+        private String name;
+
+        private BigDecimal approvalAmount;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/com/example/loan/repository/JudgmentRepository.java
+++ b/src/main/java/com/example/loan/repository/JudgmentRepository.java
@@ -1,0 +1,9 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.Judgment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JudgmentRepository extends JpaRepository<Judgment, Long> {
+}

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -1,0 +1,10 @@
+package com.example.loan.service;
+
+
+import static com.example.loan.dto.JudgmentDTO.*;
+
+public interface JudgmentService {
+
+    Response create(Request request);
+}
+

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -1,0 +1,44 @@
+package com.example.loan.service;
+
+import com.example.loan.domain.Judgment;
+import com.example.loan.exception.BaseException;
+import com.example.loan.exception.ResultType;
+import com.example.loan.repository.ApplicationRepository;
+import com.example.loan.repository.JudgmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import static com.example.loan.dto.JudgmentDTO.Request;
+import static com.example.loan.dto.JudgmentDTO.Response;
+
+@Service
+@RequiredArgsConstructor
+public class JudgmentServiceImpl implements JudgmentService {
+
+    private final JudgmentRepository judgmentRepository;
+
+    private final ModelMapper modelMapper;
+
+    private final ApplicationRepository applicationRepository;
+
+    @Override
+    public Response create(Request request) {
+        // 신청 정보 검증
+        Long applicationId = request.getApplicationId();
+        if (!isPresentApplication(applicationId)) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+        // request dto -> entity -> save
+        Judgment judgment = modelMapper.map(request, Judgment.class);
+
+        Judgment saved = judgmentRepository.save(judgment);
+        // save -> response dto
+
+        return modelMapper.map(saved, Response.class);
+    }
+
+    private boolean isPresentApplication(Long applicationId) {
+        return applicationRepository.findById(applicationId).isPresent();
+    }
+}

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.loan.service;
+
+import com.example.loan.domain.Application;
+import com.example.loan.domain.Judgment;
+import com.example.loan.dto.JudgmentDTO;
+import com.example.loan.repository.ApplicationRepository;
+import com.example.loan.repository.JudgmentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static com.example.loan.dto.JudgmentDTO.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class JudgmentServiceTest {
+
+    @InjectMocks
+    private JudgmentServiceImpl judgmentService;
+
+    @Mock
+    private JudgmentRepository judgmentRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    @Test
+    void Should_ReturnResponseOfNewJudgmentEntity_WHen_RequestNewJudgment(){
+        Judgment judgment = Judgment.builder()
+                .applicationId(1L)
+                .name("Member Kim")
+                .approvalAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        Request request = Request.builder()
+                .applicationId(1L)
+                .name("Member Kim")
+                .approvalAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        // application find
+        when(applicationRepository.findById(1L)).thenReturn(Optional.ofNullable(Application.builder().build()));
+        // judgment save
+        when(judgmentRepository.save(ArgumentMatchers.any(Judgment.class))).thenReturn(judgment);
+
+        Response actual = judgmentService.create(request);
+
+        assertThat(actual.getName()).isSameAs(judgment.getName());
+        assertThat(actual.getApplicationId()).isSameAs(judgment.getApplicationId());
+        assertThat(actual.getApprovalAmount()).isSameAs(judgment.getApprovalAmount());
+    }
+}


### PR DESCRIPTION
이 PR은 대출 심사 등록 기능을 구현한다.

- `JudgmentController`: 대출 심사 등록 API를 구현
- `JudgmentDTO`: 요청(Request) 및 응답(Response) 처리 클래스 추가
- `JudgmentRepository`: 심사 데이터를 저장하고 조회하는 기능 구현
- `JudgmentService` 및 `JudgmentServiceImpl`: 대출 심사 로직 처리
- `JudgmentServiceTest`: 대출 심사 등록 기능에 대한 단위 테스트 작성