### PR TITLE
대출 심사 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -1,12 +1,10 @@
 package com.example.loan.controller;
 
+import com.example.loan.dto.JudgmentDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.JudgmentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
@@ -22,4 +20,15 @@ public class JudgmentController extends AbstractController {
     public ResponseDTO<Response> create(@RequestBody Request request) {
         return ok(judgmentService.create(request));
     }
+
+    @GetMapping("/{judgmentId}")
+    public ResponseDTO<Response> get(@PathVariable Long judgmentId) {
+        return ok(judgmentService.get(judgmentId));
+    }
+
+    @GetMapping("/applications/{applicationId}")
+    public ResponseDTO<Response> getJudgmentOfApplication(@PathVariable Long applicationId) {
+        return ok(judgmentService.getJudgmentOfApplication(applicationId));
+    }
+
 }

--- a/src/main/java/com/example/loan/repository/JudgmentRepository.java
+++ b/src/main/java/com/example/loan/repository/JudgmentRepository.java
@@ -4,6 +4,10 @@ import com.example.loan.domain.Judgment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface JudgmentRepository extends JpaRepository<Judgment, Long> {
+
+    Optional<Judgment> findAllByApplicationId(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -6,5 +6,9 @@ import static com.example.loan.dto.JudgmentDTO.*;
 public interface JudgmentService {
 
     Response create(Request request);
+
+    Response get(Long judgmentId);
+
+    Response getJudgmentOfApplication(Long applicationId);
 }
 

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -38,6 +38,28 @@ public class JudgmentServiceImpl implements JudgmentService {
         return modelMapper.map(saved, Response.class);
     }
 
+    @Override
+    public Response get(Long judgmentId) {
+        Judgment judgment = judgmentRepository.findById(judgmentId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        return modelMapper.map(judgment, Response.class);
+    }
+
+    @Override
+    public Response getJudgmentOfApplication(Long applicationId) {
+        if (!isPresentApplication(applicationId)) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        Judgment judgment = judgmentRepository.findAllByApplicationId(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        return modelMapper.map(judgment, Response.class);
+    }
+
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();
     }

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -2,19 +2,22 @@ package com.example.loan.service;
 
 import com.example.loan.domain.Application;
 import com.example.loan.domain.Judgment;
-import com.example.loan.dto.JudgmentDTO;
 import com.example.loan.repository.ApplicationRepository;
 import com.example.loan.repository.JudgmentRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 import java.math.BigDecimal;
 import java.util.Optional;
 
-import static com.example.loan.dto.JudgmentDTO.*;
+import static com.example.loan.dto.JudgmentDTO.Request;
+import static com.example.loan.dto.JudgmentDTO.Response;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +37,7 @@ public class JudgmentServiceTest {
     private ModelMapper modelMapper;
 
     @Test
-    void Should_ReturnResponseOfNewJudgmentEntity_WHen_RequestNewJudgment(){
+    void Should_ReturnResponseOfNewJudgmentEntity_WHen_RequestNewJudgment() {
         Judgment judgment = Judgment.builder()
                 .applicationId(1L)
                 .name("Member Kim")
@@ -57,5 +60,38 @@ public class JudgmentServiceTest {
         assertThat(actual.getName()).isSameAs(judgment.getName());
         assertThat(actual.getApplicationId()).isSameAs(judgment.getApplicationId());
         assertThat(actual.getApprovalAmount()).isSameAs(judgment.getApprovalAmount());
+    }
+
+
+    @Test
+    void Should_ReturnResponseOfExistJudgmentEntity_When_RequestExistJudgmentId() {
+
+        Judgment entity = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+        when(judgmentRepository.findById(1L)).thenReturn(Optional.ofNullable(entity));
+
+        Response actual = judgmentService.get(1L);
+
+        assertThat(actual.getJudgmentId()).isSameAs(1L);
+    }
+
+    @Test
+    void Should_ReturnResponseOfExistJudgmentEntity_When_RequestExistApplicationId() {
+
+        Judgment judgmentEntity = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+
+        Application applicationEntity = Application.builder()
+                .applicationId(1L)
+                .build();
+
+        when(applicationRepository.findById(1L)).thenReturn(Optional.ofNullable(applicationEntity));
+        when(judgmentRepository.findAllByApplicationId(1L)).thenReturn(Optional.ofNullable(judgmentEntity));
+
+        Response actual = judgmentService.getJudgmentOfApplication(1L);
+
+        assertThat(actual.getJudgmentId()).isSameAs(1L);
     }
 }


### PR DESCRIPTION
이 PR은 대출 심사 조회 기능을 구현한다.

- `JudgmentController`: 심사 ID와 신청 ID로 조회하는 메서드 추가
- `JudgmentService` 및 `JudgmentServiceImpl`: 심사 및 신청 정보를 기반으로 조회하는 로직 구현
- `JudgmentRepository`: 신청 ID로 심사 데이터를 조회하는 메서드 추가
- `JudgmentServiceTest`: 심사 및 신청 ID로 조회하는 테스트 케이스 작성