### PR TITLE
대출 심사 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -31,4 +31,9 @@ public class JudgmentController extends AbstractController {
         return ok(judgmentService.getJudgmentOfApplication(applicationId));
     }
 
+    @PutMapping("/{judgmentId}")
+    public ResponseDTO<Response> update(@PathVariable Long judgmentId, @RequestBody Request request) {
+        return ok(judgmentService.update(judgmentId, request));
+    }
+
 }

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -10,5 +10,7 @@ public interface JudgmentService {
     Response get(Long judgmentId);
 
     Response getJudgmentOfApplication(Long applicationId);
+
+    Response update(Long judgmentId, Request request);
 }
 

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -16,6 +16,7 @@ import static com.example.loan.dto.JudgmentDTO.Response;
 @RequiredArgsConstructor
 public class JudgmentServiceImpl implements JudgmentService {
 
+
     private final JudgmentRepository judgmentRepository;
 
     private final ModelMapper modelMapper;
@@ -60,7 +61,22 @@ public class JudgmentServiceImpl implements JudgmentService {
         return modelMapper.map(judgment, Response.class);
     }
 
+    @Override
+    public Response update(Long judgmentId, Request request) {
+        Judgment judgment = judgmentRepository.findById(judgmentId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        judgment.setName(request.getName());
+        judgment.setApprovalAmount(request.getApprovalAmount());
+
+        judgmentRepository.save(judgment);
+
+        return modelMapper.map(judgment, Response.class);
+    }
+
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();
     }
+
 }

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -93,5 +94,29 @@ public class JudgmentServiceTest {
         Response actual = judgmentService.getJudgmentOfApplication(1L);
 
         assertThat(actual.getJudgmentId()).isSameAs(1L);
+    }
+
+    @Test
+    void Should_ReturnUpdatedResponseOfExistJudgmentEntity_When_RequestUpdateExistJudgmentInfo() {
+
+        Judgment entity = Judgment.builder()
+                .judgmentId(1L)
+                .name("Member Kim")
+                .approvalAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        Request request = Request.builder()
+                .name("Member Lee")
+                .approvalAmount(BigDecimal.valueOf(10000000))
+                .build();
+
+        when(judgmentRepository.findById(1L)).thenReturn(Optional.ofNullable(entity));
+        when(judgmentRepository.save(ArgumentMatchers.any(Judgment.class))).thenReturn(entity);
+
+        Response actual = judgmentService.update(1L, request);
+
+        assertThat(actual.getJudgmentId()).isSameAs(1L);
+        assertThat(actual.getName()).isSameAs(request.getName());
+        assertThat(actual.getApprovalAmount()).isSameAs(request.getApprovalAmount());
     }
 }


### PR DESCRIPTION
이 PR은 대출 심사 수정 기능을 구현한다.

- JudgmentController: 심사 ID를 사용하여 심사 정보를 수정하는 API 메서드 추가
- JudgmentService 및 JudgmentServiceImpl: 심사자 이름과 승인 금액을 수정하는 로직 구현
- JudgmentServiceTest: 심사 수정 기능에 대한 단위 테스트 작성