### PR TITLE
대출 심사 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -36,4 +36,9 @@ public class JudgmentController extends AbstractController {
         return ok(judgmentService.update(judgmentId, request));
     }
 
+    @DeleteMapping("/{judgmentId}")
+    public ResponseDTO<Void> delete(@PathVariable Long judgmentId) {
+        judgmentService.delete(judgmentId);
+        return ok();
+    }
 }

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -12,5 +12,7 @@ public interface JudgmentService {
     Response getJudgmentOfApplication(Long applicationId);
 
     Response update(Long judgmentId, Request request);
+
+    void delete(Long judgmentId);
 }
 

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.sql.Struct;
+
 import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
 
@@ -74,6 +76,18 @@ public class JudgmentServiceImpl implements JudgmentService {
 
         return modelMapper.map(judgment, Response.class);
     }
+
+    @Override
+    public void delete(Long judgmentId) {
+        Judgment judgment = judgmentRepository.findById(judgmentId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        judgment.setIsDeleted(true);
+
+        judgmentRepository.save(judgment);
+    }
+
 
     private boolean isPresentApplication(Long applicationId) {
         return applicationRepository.findById(applicationId).isPresent();

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -20,6 +20,7 @@ import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.optional;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -118,5 +119,20 @@ public class JudgmentServiceTest {
         assertThat(actual.getJudgmentId()).isSameAs(1L);
         assertThat(actual.getName()).isSameAs(request.getName());
         assertThat(actual.getApprovalAmount()).isSameAs(request.getApprovalAmount());
+    }
+
+    @Test
+    void Should_DeletedJudgmentEntity_When_RequestDeleteExistJudgmentInfo() {
+        Judgment entity = Judgment.builder()
+                .judgmentId(1L)
+                .build();
+
+        when(judgmentRepository.findById(1L)).thenReturn(Optional.ofNullable(entity));
+        when(judgmentRepository.save(ArgumentMatchers.any(Judgment.class))).thenReturn(entity);
+
+        judgmentService.delete(1L);
+
+        assertThat(entity.getIsDeleted()).isTrue();
+
     }
 }


### PR DESCRIPTION
이 PR은 대출 심사 삭제 기능을 구현한다.

- JudgmentController: 심사 ID를 사용하여 심사 정보를 삭제하는 API 메서드 추가
- JudgmentService 및 JudgmentServiceImpl: 심사 정보를 소프트 삭제하는 로직 구현
- JudgmentServiceTest: 심사 삭제 기능에 대한 단위 테스트 작성