### PR TITLE
대출 심사 금액 부여 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/JudgmentController.java
+++ b/src/main/java/com/example/loan/controller/JudgmentController.java
@@ -1,11 +1,13 @@
 package com.example.loan.controller;
 
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.dto.JudgmentDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.JudgmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static com.example.loan.dto.ApplicationDTO.*;
 import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
 
@@ -40,5 +42,10 @@ public class JudgmentController extends AbstractController {
     public ResponseDTO<Void> delete(@PathVariable Long judgmentId) {
         judgmentService.delete(judgmentId);
         return ok();
+    }
+
+    @PatchMapping("/{judgmentId}/grants")
+    public ResponseDTO<GrantAmount> grant(@PathVariable Long judgmentId) {
+        return ok(judgmentService.grant(judgmentId));
     }
 }

--- a/src/main/java/com/example/loan/dto/ApplicationDTO.java
+++ b/src/main/java/com/example/loan/dto/ApplicationDTO.java
@@ -62,4 +62,19 @@ public class ApplicationDTO implements Serializable {
     public static class AcceptTerms {
         List<Long> acceptTermsIds;
     }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class GrantAmount {
+        private Long applicationId;
+
+        private BigDecimal approvalAmount;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/com/example/loan/service/JudgmentService.java
+++ b/src/main/java/com/example/loan/service/JudgmentService.java
@@ -1,6 +1,8 @@
 package com.example.loan.service;
 
 
+import com.example.loan.dto.ApplicationDTO;
+
 import static com.example.loan.dto.JudgmentDTO.*;
 
 public interface JudgmentService {
@@ -14,5 +16,7 @@ public interface JudgmentService {
     Response update(Long judgmentId, Request request);
 
     void delete(Long judgmentId);
+
+    ApplicationDTO.GrantAmount grant(Long judgmentId);
 }
 

--- a/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
+++ b/src/main/java/com/example/loan/service/JudgmentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.loan.service;
 
+import com.example.loan.domain.Application;
 import com.example.loan.domain.Judgment;
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.exception.BaseException;
 import com.example.loan.exception.ResultType;
 import com.example.loan.repository.ApplicationRepository;
@@ -9,8 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.sql.Struct;
 
+import static com.example.loan.dto.ApplicationDTO.*;
 import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
 
@@ -86,6 +90,25 @@ public class JudgmentServiceImpl implements JudgmentService {
         judgment.setIsDeleted(true);
 
         judgmentRepository.save(judgment);
+    }
+
+    @Override
+    public GrantAmount grant(Long judgmentId) {
+        Judgment judgment = judgmentRepository.findById(judgmentId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        Long applicationId = judgment.getApplicationId();
+        Application application = applicationRepository.findById(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        BigDecimal approvalAmount = judgment.getApprovalAmount();
+        application.setApprovalAmount(approvalAmount);
+
+        applicationRepository.save(application);
+
+        return modelMapper.map(application, GrantAmount.class);
     }
 
 

--- a/src/test/java/com/example/loan/service/JudgmentServiceTest.java
+++ b/src/test/java/com/example/loan/service/JudgmentServiceTest.java
@@ -2,6 +2,7 @@ package com.example.loan.service;
 
 import com.example.loan.domain.Application;
 import com.example.loan.domain.Judgment;
+import com.example.loan.dto.ApplicationDTO;
 import com.example.loan.repository.ApplicationRepository;
 import com.example.loan.repository.JudgmentRepository;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.modelmapper.ModelMapper;
 import java.math.BigDecimal;
 import java.util.Optional;
 
+import static com.example.loan.dto.ApplicationDTO.*;
 import static com.example.loan.dto.JudgmentDTO.Request;
 import static com.example.loan.dto.JudgmentDTO.Response;
 import static org.assertj.core.api.Assertions.as;
@@ -133,6 +135,29 @@ public class JudgmentServiceTest {
         judgmentService.delete(1L);
 
         assertThat(entity.getIsDeleted()).isTrue();
+    }
 
+    @Test
+    void Should_ReturnUpdateResponseOfExistJudgmentEntity_When_RequestGrantApprovalAmountExistJudgmentInfo() {
+
+        Judgment judgmentEntity = Judgment.builder()
+                .name("Member Kim")
+                .applicationId(1L)
+                .approvalAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        Application applicationEntity = Application.builder()
+                .applicationId(1L)
+                .approvalAmount(BigDecimal.valueOf(5000000))
+                .build();
+
+        when(judgmentRepository.findById(1L)).thenReturn(Optional.ofNullable(judgmentEntity));
+        when(applicationRepository.findById(1L)).thenReturn(Optional.ofNullable(applicationEntity));
+        when(applicationRepository.save(ArgumentMatchers.any(Application.class))).thenReturn(applicationEntity);
+
+        GrantAmount actual = judgmentService.grant(1L);
+
+        assertThat(actual.getApplicationId()).isSameAs(1L);
+        assertThat(actual.getApprovalAmount()).isSameAs(applicationEntity.getApprovalAmount());
     }
 }


### PR DESCRIPTION
이 PR은 대출 심사 승인 금액 부여 기능을 구현한다.

- JudgmentController: 심사 ID를 통해 승인 금액을 대출 신청에 반영하는 API 메서드 추가
- JudgmentService 및 JudgmentServiceImpl: 승인 금액을 대출 신청에 반영하는 로직 구현
- GrantAmount DTO: 승인 금액을 처리하기 위한 DTO 클래스 추가
- JudgmentServiceTest: 승인 금액 부여 기능에 대한 단위 테스트 작성