### PR TITLE
대출 집행 등록 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -1,0 +1,22 @@
+package com.example.loan.controller;
+
+
+import com.example.loan.dto.ResponseDTO;
+import com.example.loan.service.EntryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.loan.dto.EntryDTO.Request;
+import static com.example.loan.dto.EntryDTO.Response;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/internal/applications")
+public class InternalController extends AbstractController{
+    private final EntryService entryService;
+
+    @PostMapping("{applicationId}/entries")
+    public ResponseDTO<Response> create(@PathVariable Long applicationId, @RequestBody Request request) {
+        return ok(entryService.create(applicationId, request));
+    }
+}

--- a/src/main/java/com/example/loan/dto/BalanceDTO.java
+++ b/src/main/java/com/example/loan/dto/BalanceDTO.java
@@ -1,0 +1,40 @@
+package com.example.loan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+public class BalanceDTO implements Serializable {
+
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Service
+    public static class Request{
+
+        private Long applicationId;
+
+        private BigDecimal entryAmount;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Service
+    public static class Response{
+
+        private Long balanceId;
+
+        private Long applicationId;
+
+        private BigDecimal balance;
+    }
+}

--- a/src/main/java/com/example/loan/dto/EntryDTO.java
+++ b/src/main/java/com/example/loan/dto/EntryDTO.java
@@ -1,0 +1,38 @@
+package com.example.loan.dto;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class EntryDTO implements Serializable {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Request{
+        private BigDecimal entryAmount;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Response{
+
+        private Long entryId;
+
+        private Long applicationId;
+
+        private BigDecimal entryAmount;
+
+        private LocalDateTime createdAt;
+
+        private LocalDateTime updatedAt;
+
+    }
+}

--- a/src/main/java/com/example/loan/repository/BalanceRepository.java
+++ b/src/main/java/com/example/loan/repository/BalanceRepository.java
@@ -1,0 +1,14 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.Balance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BalanceRepository extends JpaRepository<Balance, Long> {
+
+    Optional<Balance> findByApplicationId(Long applicationId);
+
+}

--- a/src/main/java/com/example/loan/repository/EntryRepository.java
+++ b/src/main/java/com/example/loan/repository/EntryRepository.java
@@ -1,0 +1,10 @@
+package com.example.loan.repository;
+
+import com.example.loan.domain.Entry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping
+public interface EntryRepository extends JpaRepository<Entry, Long> {
+
+}

--- a/src/main/java/com/example/loan/service/BalanceService.java
+++ b/src/main/java/com/example/loan/service/BalanceService.java
@@ -1,0 +1,9 @@
+package com.example.loan.service;
+
+import static com.example.loan.dto.BalanceDTO.Request;
+import static com.example.loan.dto.BalanceDTO.Response;
+
+public interface BalanceService {
+
+    Response create(Long applicationId, Request request);
+}

--- a/src/main/java/com/example/loan/service/BalanceServiceImpl.java
+++ b/src/main/java/com/example/loan/service/BalanceServiceImpl.java
@@ -1,0 +1,40 @@
+package com.example.loan.service;
+
+import com.example.loan.domain.Balance;
+import com.example.loan.exception.BaseException;
+import com.example.loan.exception.ResultType;
+import com.example.loan.repository.BalanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+import static com.example.loan.dto.BalanceDTO.Request;
+import static com.example.loan.dto.BalanceDTO.Response;
+
+@Service
+@RequiredArgsConstructor
+public class BalanceServiceImpl implements BalanceService{
+
+    private final BalanceRepository balanceRepository;
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Response create(Long applicationId, Request request) {
+        if (balanceRepository.findByApplicationId(applicationId).isPresent()) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        Balance balance = modelMapper.map(request, Balance.class);
+
+        BigDecimal entryAmount = request.getEntryAmount();
+        balance.setApplicationId(applicationId);
+        balance.setBalance(entryAmount);
+
+        Balance saved = balanceRepository.save(balance);
+
+        return modelMapper.map(saved, Response.class);
+    }
+}

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -1,0 +1,9 @@
+package com.example.loan.service;
+
+import static com.example.loan.dto.EntryDTO.Request;
+import static com.example.loan.dto.EntryDTO.Response;
+
+public interface EntryService {
+
+    Response create(Long applicationId, Request request);
+}

--- a/src/main/java/com/example/loan/service/EntryServiceImpl.java
+++ b/src/main/java/com/example/loan/service/EntryServiceImpl.java
@@ -1,0 +1,61 @@
+package com.example.loan.service;
+
+import com.example.loan.domain.Application;
+import com.example.loan.domain.Entry;
+import com.example.loan.dto.BalanceDTO;
+import com.example.loan.exception.BaseException;
+import com.example.loan.exception.ResultType;
+import com.example.loan.repository.ApplicationRepository;
+import com.example.loan.repository.EntryRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.example.loan.dto.EntryDTO.Request;
+import static com.example.loan.dto.EntryDTO.Response;
+
+@Service
+@RequiredArgsConstructor
+public class EntryServiceImpl implements EntryService {
+
+    private final BalanceService balanceService;
+
+    private final EntryRepository entryRepository;
+
+    private final ApplicationRepository applicationRepository;
+
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Response create(Long applicationId, Request request) {
+        // 계약 체결 여부 검증
+        if (isContractedApplication(applicationId)) {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        }
+
+        Entry entry = modelMapper.map(request, Entry.class);
+        entry.setApplicationId(applicationId);
+
+        entryRepository.save(entry);
+
+        // 대출 잔고 관리
+        balanceService.create(applicationId
+                , BalanceDTO.Request.builder()
+                                .entryAmount(request.getEntryAmount())
+                        .build());
+
+        return modelMapper.map(entry, Response.class);
+    }
+
+
+
+    private boolean isContractedApplication(Long applicationId) {
+        Optional<Application> existed = applicationRepository.findById(applicationId);
+        if (existed.isPresent()) {
+            return false;
+        }
+        return existed.get().getContractedAt() != null;
+    }
+}


### PR DESCRIPTION
이 PR은 대출 집행 및 잔고 관리 기능을 구현한다.

- `InternalController`: 대출 신청에 대한 집행을 처리하는 API 추가
- `BalanceDTO`: 대출 잔고 정보를 관리하는 DTO 추가
- `EntryDTO`: 대출 집행 관련 요청 및 응답을 처리하는 DTO 추가
- `BalanceRepository`: 대출 잔고 정보를 관리하는 Repository 추가
- `EntryRepository`: 대출 집행 내역을 관리하는 Repository 추가
- `BalanceService`, `BalanceServiceImpl`: 대출 잔고 관리 로직 구현
- `EntryService`, `EntryServiceImpl`: 대출 집행 로직 구현