### PR TITLE
대출 집행 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -19,4 +19,9 @@ public class InternalController extends AbstractController{
     public ResponseDTO<Response> create(@PathVariable Long applicationId, @RequestBody Request request) {
         return ok(entryService.create(applicationId, request));
     }
+
+    @GetMapping("{applicationId}/entries")
+    public ResponseDTO<Response> get(@PathVariable Long applicationId) {
+        return ok(entryService.get(applicationId));
+    }
 }

--- a/src/main/java/com/example/loan/repository/EntryRepository.java
+++ b/src/main/java/com/example/loan/repository/EntryRepository.java
@@ -4,7 +4,10 @@ import com.example.loan.domain.Entry;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.Optional;
+
 @RequestMapping
 public interface EntryRepository extends JpaRepository<Entry, Long> {
 
+    Optional<Entry> findByApplicationId(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -6,4 +6,6 @@ import static com.example.loan.dto.EntryDTO.Response;
 public interface EntryService {
 
     Response create(Long applicationId, Request request);
+
+    Response get(Long applicationId);
 }

--- a/src/main/java/com/example/loan/service/EntryServiceImpl.java
+++ b/src/main/java/com/example/loan/service/EntryServiceImpl.java
@@ -49,6 +49,16 @@ public class EntryServiceImpl implements EntryService {
         return modelMapper.map(entry, Response.class);
     }
 
+    @Override
+    public Response get(Long applicationId) {
+        Optional<Entry> entry = entryRepository.findByApplicationId(applicationId);
+
+        if(entry.isPresent()){
+            return modelMapper.map(entry, Response.class);
+        }else{
+            return null;
+        }
+    }
 
 
     private boolean isContractedApplication(Long applicationId) {


### PR DESCRIPTION
이 PR은 대출 집행 조회 기능을 구현한다.


- `InternalController`: 대출 신청에 대한 집행 내역을 조회하는 API 추가
- `EntryRepository`: 대출 신청 ID를 기반으로 집행 내역을 조회하는 메서드 추가
- `EntryService`, `EntryServiceImpl`: 대출 집행 내역 조회 로직 구현