### PR TITLE
대출 집행 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -1,11 +1,13 @@
 package com.example.loan.controller;
 
 
+import com.example.loan.dto.EntryDTO;
 import com.example.loan.dto.ResponseDTO;
 import com.example.loan.service.EntryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static com.example.loan.dto.EntryDTO.*;
 import static com.example.loan.dto.EntryDTO.Request;
 import static com.example.loan.dto.EntryDTO.Response;
 
@@ -23,5 +25,10 @@ public class InternalController extends AbstractController{
     @GetMapping("{applicationId}/entries")
     public ResponseDTO<Response> get(@PathVariable Long applicationId) {
         return ok(entryService.get(applicationId));
+    }
+
+    @PutMapping("/entries/{entryId}")
+    public ResponseDTO<UpdateResponse> update(@PathVariable Long entryId, @RequestBody Request request) {
+        return ok(entryService.update(entryId, request));
     }
 }

--- a/src/main/java/com/example/loan/dto/BalanceDTO.java
+++ b/src/main/java/com/example/loan/dto/BalanceDTO.java
@@ -29,6 +29,20 @@ public class BalanceDTO implements Serializable {
     @Builder
     @Getter
     @Service
+    public static class UpdateRequest{
+
+        private Long applicationId;
+
+        private BigDecimal beforeEntryAmount;
+
+        private BigDecimal afterEntryAmount;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Service
     public static class Response{
 
         private Long balanceId;

--- a/src/main/java/com/example/loan/dto/EntryDTO.java
+++ b/src/main/java/com/example/loan/dto/EntryDTO.java
@@ -35,4 +35,21 @@ public class EntryDTO implements Serializable {
         private LocalDateTime updatedAt;
 
     }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class UpdateResponse{
+
+        private Long entryId;
+
+        private Long applicationId;
+
+        private BigDecimal beforeEntryAmount;
+
+        private BigDecimal afterEntryAmount;
+
+    }
 }

--- a/src/main/java/com/example/loan/service/BalanceService.java
+++ b/src/main/java/com/example/loan/service/BalanceService.java
@@ -1,9 +1,14 @@
 package com.example.loan.service;
 
+import com.example.loan.dto.BalanceDTO;
+import com.example.loan.dto.BalanceDTO.UpdateRequest;
+
 import static com.example.loan.dto.BalanceDTO.Request;
 import static com.example.loan.dto.BalanceDTO.Response;
 
 public interface BalanceService {
 
     Response create(Long applicationId, Request request);
+
+    Response update(Long applicationId, UpdateRequest request);
 }

--- a/src/main/java/com/example/loan/service/BalanceServiceImpl.java
+++ b/src/main/java/com/example/loan/service/BalanceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.loan.service;
 
 import com.example.loan.domain.Balance;
+import com.example.loan.dto.BalanceDTO;
 import com.example.loan.exception.BaseException;
 import com.example.loan.exception.ResultType;
 import com.example.loan.repository.BalanceRepository;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 
+import static com.example.loan.dto.BalanceDTO.*;
 import static com.example.loan.dto.BalanceDTO.Request;
 import static com.example.loan.dto.BalanceDTO.Response;
 
@@ -36,5 +38,26 @@ public class BalanceServiceImpl implements BalanceService{
         Balance saved = balanceRepository.save(balance);
 
         return modelMapper.map(saved, Response.class);
+    }
+
+    @Override
+    public Response update(Long applicationId, UpdateRequest request) {
+
+        // balance
+        Balance balance = balanceRepository.findByApplicationId(applicationId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        BigDecimal beforeEntryAmount = request.getBeforeEntryAmount();
+        BigDecimal afterEntryAmount = request.getAfterEntryAmount();
+        BigDecimal updatedBalance = balance.getBalance();
+
+        updatedBalance = updatedBalance.subtract(beforeEntryAmount).add(afterEntryAmount);
+        balance.setBalance(updatedBalance);
+
+        Balance updated = balanceRepository.save(balance);
+
+        // as-id -> to-be
+        return modelMapper.map(updated, Response.class);
     }
 }

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -1,5 +1,8 @@
 package com.example.loan.service;
 
+import com.example.loan.dto.EntryDTO;
+
+import static com.example.loan.dto.EntryDTO.*;
 import static com.example.loan.dto.EntryDTO.Request;
 import static com.example.loan.dto.EntryDTO.Response;
 
@@ -8,4 +11,6 @@ public interface EntryService {
     Response create(Long applicationId, Request request);
 
     Response get(Long applicationId);
+
+    UpdateResponse update(Long entryId, Request request);
 }

--- a/src/main/java/com/example/loan/service/EntryServiceImpl.java
+++ b/src/main/java/com/example/loan/service/EntryServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.loan.service;
 import com.example.loan.domain.Application;
 import com.example.loan.domain.Entry;
 import com.example.loan.dto.BalanceDTO;
+import com.example.loan.dto.EntryDTO;
 import com.example.loan.exception.BaseException;
 import com.example.loan.exception.ResultType;
 import com.example.loan.repository.ApplicationRepository;
@@ -11,8 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
+import static com.example.loan.dto.BalanceDTO.*;
+import static com.example.loan.dto.EntryDTO.*;
 import static com.example.loan.dto.EntryDTO.Request;
 import static com.example.loan.dto.EntryDTO.Response;
 
@@ -43,7 +47,7 @@ public class EntryServiceImpl implements EntryService {
         // 대출 잔고 관리
         balanceService.create(applicationId
                 , BalanceDTO.Request.builder()
-                                .entryAmount(request.getEntryAmount())
+                        .entryAmount(request.getEntryAmount())
                         .build());
 
         return modelMapper.map(entry, Response.class);
@@ -53,11 +57,39 @@ public class EntryServiceImpl implements EntryService {
     public Response get(Long applicationId) {
         Optional<Entry> entry = entryRepository.findByApplicationId(applicationId);
 
-        if(entry.isPresent()){
+        if (entry.isPresent()) {
             return modelMapper.map(entry, Response.class);
-        }else{
+        } else {
             return null;
         }
+    }
+
+    @Override
+    public UpdateResponse update(Long entryId, Request request) {
+        // entry
+        Entry entry = entryRepository.findById(entryId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        // before -> after
+        BigDecimal beforeEntryAmount = entry.getEntryAmount();
+        entry.setEntryAmount(request.getEntryAmount());
+
+        entryRepository.save(entry);
+
+        // balance update
+        Long applicationId = entry.getApplicationId();
+        balanceService.update(applicationId, UpdateRequest.builder()
+                .beforeEntryAmount(beforeEntryAmount)
+                .afterEntryAmount(request.getEntryAmount())
+                .build());
+        // response
+        return UpdateResponse.builder()
+                .entryId(entryId)
+                .applicationId(applicationId)
+                .beforeEntryAmount(beforeEntryAmount)
+                .afterEntryAmount(request.getEntryAmount())
+                .build();
     }
 
 


### PR DESCRIPTION
이 PR은 대출 집행 수정 기능을 구현한다.

- `InternalController`: 대출 신청에 대한 집행 내역을 수정하는 API 추가
- `BalanceDTO`, `EntryDTO`: 대출 집행 및 잔고 수정을 위한 DTO 클래스 추가
- `BalanceService`, `BalanceServiceImpl`: 대출 잔고 수정 로직 구현
- `EntryService`, `EntryServiceImpl`: 대출 집행 금액 수정 및 잔고 업데이트 로직 구현
