### PR TITLE
대출 집행 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/loan/controller/InternalController.java
+++ b/src/main/java/com/example/loan/controller/InternalController.java
@@ -14,7 +14,7 @@ import static com.example.loan.dto.EntryDTO.Response;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/internal/applications")
-public class InternalController extends AbstractController{
+public class InternalController extends AbstractController {
     private final EntryService entryService;
 
     @PostMapping("{applicationId}/entries")
@@ -30,5 +30,11 @@ public class InternalController extends AbstractController{
     @PutMapping("/entries/{entryId}")
     public ResponseDTO<UpdateResponse> update(@PathVariable Long entryId, @RequestBody Request request) {
         return ok(entryService.update(entryId, request));
+    }
+
+    @DeleteMapping("/entries/{entryId}")
+    public ResponseDTO<Void> delete(@PathVariable Long entryId) {
+        entryService.delete(entryId);
+        return ok();
     }
 }

--- a/src/main/java/com/example/loan/service/BalanceServiceImpl.java
+++ b/src/main/java/com/example/loan/service/BalanceServiceImpl.java
@@ -25,15 +25,18 @@ public class BalanceServiceImpl implements BalanceService{
 
     @Override
     public Response create(Long applicationId, Request request) {
-        if (balanceRepository.findByApplicationId(applicationId).isPresent()) {
-            throw new BaseException(ResultType.SYSTEM_ERROR);
-        }
-
         Balance balance = modelMapper.map(request, Balance.class);
 
         BigDecimal entryAmount = request.getEntryAmount();
         balance.setApplicationId(applicationId);
         balance.setBalance(entryAmount);
+
+        balanceRepository.findByApplicationId(applicationId).ifPresent(b ->{
+            balance.setBalance(b.getBalance());
+            balance.setIsDeleted(b.getIsDeleted());
+            balance.setCreatedAt(b.getCreatedAt());
+            balance.setUpdatedAt(b.getUpdatedAt());
+        });
 
         Balance saved = balanceRepository.save(balance);
 

--- a/src/main/java/com/example/loan/service/EntryService.java
+++ b/src/main/java/com/example/loan/service/EntryService.java
@@ -1,10 +1,6 @@
 package com.example.loan.service;
 
-import com.example.loan.dto.EntryDTO;
-
 import static com.example.loan.dto.EntryDTO.*;
-import static com.example.loan.dto.EntryDTO.Request;
-import static com.example.loan.dto.EntryDTO.Response;
 
 public interface EntryService {
 
@@ -13,4 +9,6 @@ public interface EntryService {
     Response get(Long applicationId);
 
     UpdateResponse update(Long entryId, Request request);
+
+    void delete(Long entryId);
 }

--- a/src/main/java/com/example/loan/service/EntryServiceImpl.java
+++ b/src/main/java/com/example/loan/service/EntryServiceImpl.java
@@ -92,6 +92,26 @@ public class EntryServiceImpl implements EntryService {
                 .build();
     }
 
+    @Override
+    public void delete(Long entryId) {
+        Entry entry = entryRepository.findById(entryId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        entry.setIsDeleted(true);
+
+        entryRepository.save(entry);
+
+        BigDecimal beforeEntryAmount = entry.getEntryAmount();
+
+        Long applicationId = entry.getApplicationId();
+        balanceService.update(applicationId,
+                BalanceDTO.UpdateRequest.builder()
+                        .beforeEntryAmount(beforeEntryAmount)
+                        .afterEntryAmount(BigDecimal.ZERO)
+                        .build());
+    }
+
 
     private boolean isContractedApplication(Long applicationId) {
         Optional<Application> existed = applicationRepository.findById(applicationId);


### PR DESCRIPTION
이 PR은 대출 집행 삭제 기능을 구현한다.

- `InternalController`: 대출 신청에 대한 집행 내역 삭제 API 추가
- `EntryService`, `EntryServiceImpl`: 대출 집행 삭제 로직 및 잔고 0원 처리 구현
- `BalanceServiceImpl`: 대출 집행 삭제 시 잔고 0원으로 설정하는 로직 추가
