### PR TITLE
대출 상환 테이블 정의

### DIFF
--- a/src/main/java/com/example/loan/domain/Repayment.java
+++ b/src/main/java/com/example/loan/domain/Repayment.java
@@ -1,0 +1,32 @@
+package com.example.loan.domain;
+
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Where(clause = "is_deleted=false")
+public class Repayment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long repaymentId;
+
+    @Column(columnDefinition = "bigint NOT NULL COMMENT '신청 ID'")
+    private Long applicationId;
+
+    @Column(columnDefinition = "decimal(15, 2) NOT NULL COMMENT '상환 금액'")
+    private BigDecimal repaymentAmount;
+}


### PR DESCRIPTION
이 PR은 대출 상환 도메인을 정의한다.

- 대출 상환 내역을 저장하는 Repayment 엔티티 추가
- 상환 ID, 신청 ID, 상환 금액 필드 설정
- 대출금 상환 이력 추적 및 상환 정보 제공