### PR TITLE
Skaffold를 통한 Kubernetes 배포 

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loan
+spec:
+  selector:
+    matchLabels:
+      app: loan
+  template:
+    metadata:
+      labels:
+        app: loan
+    spec:
+      containers:
+        - name: loan
+          image: loan
+          ports:
+            - containerPort: 8080

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loan
+  namespace: default
+  labels:
+    app: loan
+spec:
+  selector:
+    app: loan
+  ports:
+    - port: 8080
+      name: http
+      targetPort: 8080
+      nodePort: 30080
+  type: LoadBalancer

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,6 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+build:
+  artifacts:
+    - image: loan
+      jib: {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,8 @@ server:
 spring:
   datasource:
     driverClassName: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://host.docker.internal:3306/loan?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+#    url: jdbc:mysql://host.docker.internal:3306/loan?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/loan?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: 1234
   jpa:


### PR DESCRIPTION
이 PR은 Skaffold를 사용하여 Kubernetes 환경에서 애플리케이션을 자동으로 배포하는 설정을 추가한다.

- skaffold.yaml 파일을 생성하여 JIB 기반 Docker 이미지 빌드 및 Kubernetes 배포 자동화
- Kubernetes deployment 설정을 통해 loan 애플리케이션 파드 생성
- service 설정을 통해 외부에서 localhost:8080을 통한 애플리케이션 접근 가능
